### PR TITLE
Add PQueue class as promise queue

### DIFF
--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -11,6 +11,7 @@ typedoc.search.data = {
     "1024": "Property",
     "2048": "Method",
     "65536": "Type literal",
+    "262144": "Accessor",
     "4194304": "Type alias"
   },
   rows: [
@@ -114,6 +115,222 @@ typedoc.search.data = {
     },
     {
       id: 14,
+      kind: 128,
+      name: "PQueue",
+      url: "classes/_tomato_js_async.pqueue.html",
+      classes: "tsd-kind-class tsd-parent-kind-external-module",
+      parent: "@tomato-js/async"
+    },
+    {
+      id: 15,
+      kind: 1024,
+      name: "isPaused",
+      url: "classes/_tomato_js_async.pqueue.html#ispaused",
+      classes: "tsd-kind-property tsd-parent-kind-class",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 16,
+      kind: 1024,
+      name: "pendingCount",
+      url: "classes/_tomato_js_async.pqueue.html#pendingcount",
+      classes: "tsd-kind-property tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 17,
+      kind: 1024,
+      name: "queue",
+      url: "classes/_tomato_js_async.pqueue.html#queue",
+      classes: "tsd-kind-property tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 18,
+      kind: 1024,
+      name: "concurrency",
+      url: "classes/_tomato_js_async.pqueue.html#concurrency",
+      classes: "tsd-kind-property tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 19,
+      kind: 512,
+      name: "constructor",
+      url: "classes/_tomato_js_async.pqueue.html#constructor",
+      classes: "tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 20,
+      kind: 262144,
+      name: "doesConcurrentAllowAnother",
+      url: "classes/_tomato_js_async.pqueue.html#doesconcurrentallowanother",
+      classes: "tsd-kind-get-signature tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 21,
+      kind: 2048,
+      name: "tryToStartAnother",
+      url: "classes/_tomato_js_async.pqueue.html#trytostartanother",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 22,
+      kind: 2048,
+      name: "next",
+      url: "classes/_tomato_js_async.pqueue.html#next",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 23,
+      kind: 2048,
+      name: "enqueue",
+      url: "classes/_tomato_js_async.pqueue.html#enqueue",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 24,
+      kind: 2048,
+      name: "dequeue",
+      url: "classes/_tomato_js_async.pqueue.html#dequeue",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 25,
+      kind: 2048,
+      name: "processQueue",
+      url: "classes/_tomato_js_async.pqueue.html#processqueue",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-private",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 26,
+      kind: 2048,
+      name: "start",
+      url: "classes/_tomato_js_async.pqueue.html#start",
+      classes: "tsd-kind-method tsd-parent-kind-class",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 27,
+      kind: 2048,
+      name: "pause",
+      url: "classes/_tomato_js_async.pqueue.html#pause",
+      classes: "tsd-kind-method tsd-parent-kind-class",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 28,
+      kind: 2048,
+      name: "add",
+      url: "classes/_tomato_js_async.pqueue.html#add",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 29,
+      kind: 2048,
+      name: "addAll",
+      url: "classes/_tomato_js_async.pqueue.html#addall",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 30,
+      kind: 2048,
+      name: "onIdle",
+      url: "classes/_tomato_js_async.pqueue.html#onidle",
+      classes: "tsd-kind-method tsd-parent-kind-class",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 31,
+      kind: 2048,
+      name: "clear",
+      url: "classes/_tomato_js_async.pqueue.html#clear",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-overwrite",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 32,
+      kind: 2048,
+      name: "size",
+      url: "classes/_tomato_js_async.pqueue.html#size",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-overwrite",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 33,
+      kind: 262144,
+      name: "pending",
+      url: "classes/_tomato_js_async.pqueue.html#pending",
+      classes: "tsd-kind-get-signature tsd-parent-kind-class",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 34,
+      kind: 2048,
+      name: "on",
+      url: "classes/_tomato_js_async.pqueue.html#on",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 35,
+      kind: 2048,
+      name: "once",
+      url: "classes/_tomato_js_async.pqueue.html#once",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 36,
+      kind: 2048,
+      name: "addEventListener",
+      url: "classes/_tomato_js_async.pqueue.html#addeventlistener",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 37,
+      kind: 2048,
+      name: "removeListener",
+      url: "classes/_tomato_js_async.pqueue.html#removelistener",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 38,
+      kind: 2048,
+      name: "emit",
+      url: "classes/_tomato_js_async.pqueue.html#emit",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 39,
+      kind: 2048,
+      name: "listeners",
+      url: "classes/_tomato_js_async.pqueue.html#listeners",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 40,
+      kind: 2048,
+      name: "clearAll",
+      url: "classes/_tomato_js_async.pqueue.html#clearall",
+      classes: "tsd-kind-method tsd-parent-kind-class tsd-is-inherited",
+      parent: "@tomato-js/async.PQueue"
+    },
+    {
+      id: 41,
       kind: 64,
       name: "promisify",
       url: "modules/_tomato_js_async.html#promisify",
@@ -121,16 +338,16 @@ typedoc.search.data = {
       parent: "@tomato-js/async"
     },
     {
-      id: 15,
+      id: 42,
       kind: 64,
       name: "sleep",
       url: "modules/_tomato_js_async.html#sleep",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/async"
     },
-    { id: 16, kind: 1, name: "@tomato-js/cookie", url: "modules/_tomato_js_cookie.html", classes: "tsd-kind-external-module" },
+    { id: 43, kind: 1, name: "@tomato-js/cookie", url: "modules/_tomato_js_cookie.html", classes: "tsd-kind-external-module" },
     {
-      id: 17,
+      id: 44,
       kind: 64,
       name: "get",
       url: "modules/_tomato_js_cookie.html#get",
@@ -138,7 +355,7 @@ typedoc.search.data = {
       parent: "@tomato-js/cookie"
     },
     {
-      id: 18,
+      id: 45,
       kind: 64,
       name: "has",
       url: "modules/_tomato_js_cookie.html#has",
@@ -146,7 +363,7 @@ typedoc.search.data = {
       parent: "@tomato-js/cookie"
     },
     {
-      id: 19,
+      id: 46,
       kind: 64,
       name: "remove",
       url: "modules/_tomato_js_cookie.html#remove",
@@ -154,16 +371,16 @@ typedoc.search.data = {
       parent: "@tomato-js/cookie"
     },
     {
-      id: 20,
+      id: 47,
       kind: 64,
       name: "set",
       url: "modules/_tomato_js_cookie.html#set",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/cookie"
     },
-    { id: 21, kind: 1, name: "@tomato-js/element", url: "modules/_tomato_js_element.html", classes: "tsd-kind-external-module" },
+    { id: 48, kind: 1, name: "@tomato-js/element", url: "modules/_tomato_js_element.html", classes: "tsd-kind-external-module" },
     {
-      id: 22,
+      id: 49,
       kind: 64,
       name: "get",
       url: "modules/_tomato_js_element.html#get",
@@ -171,7 +388,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 23,
+      id: 50,
       kind: 64,
       name: "append",
       url: "modules/_tomato_js_element.html#append",
@@ -179,7 +396,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 24,
+      id: 51,
       kind: 64,
       name: "prepend",
       url: "modules/_tomato_js_element.html#prepend",
@@ -187,7 +404,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 25,
+      id: 52,
       kind: 64,
       name: "insertBefore",
       url: "modules/_tomato_js_element.html#insertbefore",
@@ -195,7 +412,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 26,
+      id: 53,
       kind: 64,
       name: "insertAfter",
       url: "modules/_tomato_js_element.html#insertafter",
@@ -203,7 +420,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 27,
+      id: 54,
       kind: 64,
       name: "create",
       url: "modules/_tomato_js_element.html#create",
@@ -211,7 +428,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 28,
+      id: 55,
       kind: 64,
       name: "addStyle",
       url: "modules/_tomato_js_element.html#addstyle",
@@ -219,7 +436,7 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 29,
+      id: 56,
       kind: 64,
       name: "bottomVisible",
       url: "modules/_tomato_js_element.html#bottomvisible",
@@ -227,16 +444,16 @@ typedoc.search.data = {
       parent: "@tomato-js/element"
     },
     {
-      id: 30,
+      id: 57,
       kind: 64,
       name: "scrollToTop",
       url: "modules/_tomato_js_element.html#scrolltotop",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/element"
     },
-    { id: 31, kind: 1, name: "@tomato-js/env", url: "modules/_tomato_js_env.html", classes: "tsd-kind-external-module" },
+    { id: 58, kind: 1, name: "@tomato-js/env", url: "modules/_tomato_js_env.html", classes: "tsd-kind-external-module" },
     {
-      id: 32,
+      id: 59,
       kind: 64,
       name: "isBrowser",
       url: "modules/_tomato_js_env.html#isbrowser",
@@ -244,7 +461,7 @@ typedoc.search.data = {
       parent: "@tomato-js/env"
     },
     {
-      id: 33,
+      id: 60,
       kind: 64,
       name: "isExist",
       url: "modules/_tomato_js_env.html#isexist",
@@ -252,16 +469,16 @@ typedoc.search.data = {
       parent: "@tomato-js/env"
     },
     {
-      id: 34,
+      id: 61,
       kind: 64,
       name: "isURLSearchParamsExist",
       url: "modules/_tomato_js_env.html#isurlsearchparamsexist",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/env"
     },
-    { id: 35, kind: 1, name: "@tomato-js/events", url: "modules/_tomato_js_events.html", classes: "tsd-kind-external-module" },
+    { id: 62, kind: 1, name: "@tomato-js/events", url: "modules/_tomato_js_events.html", classes: "tsd-kind-external-module" },
     {
-      id: 36,
+      id: 63,
       kind: 128,
       name: "Events",
       url: "classes/_tomato_js_events.events.html",
@@ -269,7 +486,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events"
     },
     {
-      id: 37,
+      id: 64,
       kind: 1024,
       name: "events",
       url: "classes/_tomato_js_events.events.html#events",
@@ -277,7 +494,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 38,
+      id: 65,
       kind: 1024,
       name: "eventsCount",
       url: "classes/_tomato_js_events.events.html#eventscount",
@@ -285,7 +502,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 39,
+      id: 66,
       kind: 512,
       name: "constructor",
       url: "classes/_tomato_js_events.events.html#constructor",
@@ -293,7 +510,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 40,
+      id: 67,
       kind: 2048,
       name: "on",
       url: "classes/_tomato_js_events.events.html#on",
@@ -301,7 +518,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 41,
+      id: 68,
       kind: 2048,
       name: "once",
       url: "classes/_tomato_js_events.events.html#once",
@@ -309,7 +526,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 42,
+      id: 69,
       kind: 2048,
       name: "addEventListener",
       url: "classes/_tomato_js_events.events.html#addeventlistener",
@@ -317,7 +534,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 43,
+      id: 70,
       kind: 2048,
       name: "removeListener",
       url: "classes/_tomato_js_events.events.html#removelistener",
@@ -325,7 +542,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 44,
+      id: 71,
       kind: 2048,
       name: "emit",
       url: "classes/_tomato_js_events.events.html#emit",
@@ -333,7 +550,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 45,
+      id: 72,
       kind: 2048,
       name: "listeners",
       url: "classes/_tomato_js_events.events.html#listeners",
@@ -341,7 +558,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 46,
+      id: 73,
       kind: 2048,
       name: "clear",
       url: "classes/_tomato_js_events.events.html#clear",
@@ -349,7 +566,7 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 47,
+      id: 74,
       kind: 2048,
       name: "clearAll",
       url: "classes/_tomato_js_events.events.html#clearall",
@@ -357,16 +574,16 @@ typedoc.search.data = {
       parent: "@tomato-js/events.Events"
     },
     {
-      id: 48,
+      id: 75,
       kind: 2048,
       name: "size",
       url: "classes/_tomato_js_events.events.html#size",
       classes: "tsd-kind-method tsd-parent-kind-class",
       parent: "@tomato-js/events.Events"
     },
-    { id: 49, kind: 1, name: "@tomato-js/function", url: "modules/_tomato_js_function.html", classes: "tsd-kind-external-module" },
+    { id: 76, kind: 1, name: "@tomato-js/function", url: "modules/_tomato_js_function.html", classes: "tsd-kind-external-module" },
     {
-      id: 50,
+      id: 77,
       kind: 64,
       name: "aop",
       url: "modules/_tomato_js_function.html#aop",
@@ -374,7 +591,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 51,
+      id: 78,
       kind: 64,
       name: "afterReturn",
       url: "modules/_tomato_js_function.html#afterreturn",
@@ -382,7 +599,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 52,
+      id: 79,
       kind: 64,
       name: "after",
       url: "modules/_tomato_js_function.html#after",
@@ -390,7 +607,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 53,
+      id: 80,
       kind: 64,
       name: "around",
       url: "modules/_tomato_js_function.html#around",
@@ -398,7 +615,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 54,
+      id: 81,
       kind: 64,
       name: "before",
       url: "modules/_tomato_js_function.html#before",
@@ -406,7 +623,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 55,
+      id: 82,
       kind: 64,
       name: "both",
       url: "modules/_tomato_js_function.html#both",
@@ -414,7 +631,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 56,
+      id: 83,
       kind: 64,
       name: "compose",
       url: "modules/_tomato_js_function.html#compose",
@@ -422,7 +639,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 57,
+      id: 84,
       kind: 64,
       name: "curry",
       url: "modules/_tomato_js_function.html#curry",
@@ -430,7 +647,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 58,
+      id: 85,
       kind: 64,
       name: "debounce",
       url: "modules/_tomato_js_function.html#debounce",
@@ -438,7 +655,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 59,
+      id: 86,
       kind: 64,
       name: "either",
       url: "modules/_tomato_js_function.html#either",
@@ -446,7 +663,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 60,
+      id: 87,
       kind: 64,
       name: "flip",
       url: "modules/_tomato_js_function.html#flip",
@@ -454,7 +671,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 61,
+      id: 88,
       kind: 64,
       name: "inverse",
       url: "modules/_tomato_js_function.html#inverse",
@@ -462,7 +679,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 62,
+      id: 89,
       kind: 64,
       name: "once",
       url: "modules/_tomato_js_function.html#once",
@@ -470,7 +687,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 63,
+      id: 90,
       kind: 64,
       name: "partialRight",
       url: "modules/_tomato_js_function.html#partialright",
@@ -478,7 +695,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 64,
+      id: 91,
       kind: 64,
       name: "partial",
       url: "modules/_tomato_js_function.html#partial",
@@ -486,7 +703,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 65,
+      id: 92,
       kind: 64,
       name: "pipe",
       url: "modules/_tomato_js_function.html#pipe",
@@ -494,7 +711,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 66,
+      id: 93,
       kind: 64,
       name: "poll",
       url: "modules/_tomato_js_function.html#poll",
@@ -502,7 +719,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 67,
+      id: 94,
       kind: 64,
       name: "takeTime",
       url: "modules/_tomato_js_function.html#taketime",
@@ -510,7 +727,7 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 68,
+      id: 95,
       kind: 64,
       name: "throttle",
       url: "modules/_tomato_js_function.html#throttle",
@@ -518,16 +735,16 @@ typedoc.search.data = {
       parent: "@tomato-js/function"
     },
     {
-      id: 69,
+      id: 96,
       kind: 64,
       name: "times",
       url: "modules/_tomato_js_function.html#times",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/function"
     },
-    { id: 70, kind: 1, name: "@tomato-js/math", url: "modules/_tomato_js_math.html", classes: "tsd-kind-external-module" },
+    { id: 97, kind: 1, name: "@tomato-js/math", url: "modules/_tomato_js_math.html", classes: "tsd-kind-external-module" },
     {
-      id: 71,
+      id: 98,
       kind: 32,
       name: "add",
       url: "modules/_tomato_js_math.html#add",
@@ -535,7 +752,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 72,
+      id: 99,
       kind: 64,
       name: "averageBy",
       url: "modules/_tomato_js_math.html#averageby",
@@ -543,7 +760,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 73,
+      id: 100,
       kind: 64,
       name: "average",
       url: "modules/_tomato_js_math.html#average",
@@ -551,7 +768,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 74,
+      id: 101,
       kind: 32,
       name: "divide",
       url: "modules/_tomato_js_math.html#divide",
@@ -559,7 +776,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 75,
+      id: 102,
       kind: 32,
       name: "multiply",
       url: "modules/_tomato_js_math.html#multiply",
@@ -567,7 +784,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 76,
+      id: 103,
       kind: 32,
       name: "subtract",
       url: "modules/_tomato_js_math.html#subtract",
@@ -575,7 +792,7 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 77,
+      id: 104,
       kind: 64,
       name: "sumBy",
       url: "modules/_tomato_js_math.html#sumby",
@@ -583,16 +800,16 @@ typedoc.search.data = {
       parent: "@tomato-js/math"
     },
     {
-      id: 78,
+      id: 105,
       kind: 64,
       name: "sum",
       url: "modules/_tomato_js_math.html#sum",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/math"
     },
-    { id: 79, kind: 1, name: "@tomato-js/object", url: "modules/_tomato_js_object.html", classes: "tsd-kind-external-module" },
+    { id: 106, kind: 1, name: "@tomato-js/object", url: "modules/_tomato_js_object.html", classes: "tsd-kind-external-module" },
     {
-      id: 80,
+      id: 107,
       kind: 64,
       name: "deepClone",
       url: "modules/_tomato_js_object.html#deepclone",
@@ -600,7 +817,7 @@ typedoc.search.data = {
       parent: "@tomato-js/object"
     },
     {
-      id: 81,
+      id: 108,
       kind: 64,
       name: "deepGet",
       url: "modules/_tomato_js_object.html#deepget",
@@ -608,7 +825,7 @@ typedoc.search.data = {
       parent: "@tomato-js/object"
     },
     {
-      id: 82,
+      id: 109,
       kind: 64,
       name: "lazy",
       url: "modules/_tomato_js_object.html#lazy",
@@ -616,7 +833,7 @@ typedoc.search.data = {
       parent: "@tomato-js/object"
     },
     {
-      id: 83,
+      id: 110,
       kind: 64,
       name: "pickX",
       url: "modules/_tomato_js_object.html#pickx",
@@ -624,16 +841,16 @@ typedoc.search.data = {
       parent: "@tomato-js/object"
     },
     {
-      id: 84,
+      id: 111,
       kind: 64,
       name: "pick",
       url: "modules/_tomato_js_object.html#pick",
       classes: "tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter",
       parent: "@tomato-js/object"
     },
-    { id: 85, kind: 1, name: "@tomato-js/path", url: "modules/_tomato_js_path.html", classes: "tsd-kind-external-module" },
+    { id: 112, kind: 1, name: "@tomato-js/path", url: "modules/_tomato_js_path.html", classes: "tsd-kind-external-module" },
     {
-      id: 86,
+      id: 113,
       kind: 64,
       name: "getSearch",
       url: "modules/_tomato_js_path.html#getsearch",
@@ -641,7 +858,7 @@ typedoc.search.data = {
       parent: "@tomato-js/path"
     },
     {
-      id: 87,
+      id: 114,
       kind: 64,
       name: "parse",
       url: "modules/_tomato_js_path.html#parse",
@@ -649,7 +866,7 @@ typedoc.search.data = {
       parent: "@tomato-js/path"
     },
     {
-      id: 88,
+      id: 115,
       kind: 64,
       name: "stringify",
       url: "modules/_tomato_js_path.html#stringify",
@@ -657,25 +874,25 @@ typedoc.search.data = {
       parent: "@tomato-js/path"
     },
     {
-      id: 89,
+      id: 116,
       kind: 64,
       name: "merge",
       url: "modules/_tomato_js_path.html#merge",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/path"
     },
-    { id: 90, kind: 1, name: "@tomato-js/queue", url: "modules/_tomato_js_queue.html", classes: "tsd-kind-external-module" },
+    { id: 117, kind: 1, name: "@tomato-js/queue", url: "modules/_tomato_js_queue.html", classes: "tsd-kind-external-module" },
     {
-      id: 91,
+      id: 118,
       kind: 64,
       name: "chainer",
       url: "modules/_tomato_js_queue.html#chainer",
       classes: "tsd-kind-function tsd-parent-kind-external-module",
       parent: "@tomato-js/queue"
     },
-    { id: 92, kind: 1, name: "@tomato-js/shared", url: "modules/_tomato_js_shared.html", classes: "tsd-kind-external-module" },
+    { id: 119, kind: 1, name: "@tomato-js/shared", url: "modules/_tomato_js_shared.html", classes: "tsd-kind-external-module" },
     {
-      id: 93,
+      id: 120,
       kind: 256,
       name: "ObjectType",
       url: "interfaces/_tomato_js_shared.objecttype.html",
@@ -683,7 +900,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 94,
+      id: 121,
       kind: 4194304,
       name: "HTMLSelector",
       url: "modules/_tomato_js_shared.html#htmlselector",
@@ -691,7 +908,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 95,
+      id: 122,
       kind: 4194304,
       name: "HTMLElementKey",
       url: "modules/_tomato_js_shared.html#htmlelementkey",
@@ -699,7 +916,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 96,
+      id: 123,
       kind: 4194304,
       name: "Eachable",
       url: "modules/_tomato_js_shared.html#eachable",
@@ -707,7 +924,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 97,
+      id: 124,
       kind: 4194304,
       name: "FunctionType",
       url: "modules/_tomato_js_shared.html#functiontype",
@@ -715,7 +932,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 98,
+      id: 125,
       kind: 65536,
       name: "__type",
       url: "modules/_tomato_js_shared.html#functiontype.__type",
@@ -723,7 +940,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared.FunctionType"
     },
     {
-      id: 99,
+      id: 126,
       kind: 4194304,
       name: "Falsy",
       url: "modules/_tomato_js_shared.html#falsy",
@@ -731,7 +948,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 100,
+      id: 127,
       kind: 4194304,
       name: "NonUndefined",
       url: "modules/_tomato_js_shared.html#nonundefined",
@@ -739,7 +956,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 101,
+      id: 128,
       kind: 4194304,
       name: "FunctionKeys",
       url: "modules/_tomato_js_shared.html#functionkeys",
@@ -747,7 +964,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 102,
+      id: 129,
       kind: 4194304,
       name: "NonFunctionKeys",
       url: "modules/_tomato_js_shared.html#nonfunctionkeys",
@@ -755,7 +972,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 103,
+      id: 130,
       kind: 4194304,
       name: "RequiredKeys",
       url: "modules/_tomato_js_shared.html#requiredkeys",
@@ -763,7 +980,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 104,
+      id: 131,
       kind: 4194304,
       name: "OptionalKeys",
       url: "modules/_tomato_js_shared.html#optionalkeys",
@@ -771,7 +988,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 105,
+      id: 132,
       kind: 4194304,
       name: "Optional",
       url: "modules/_tomato_js_shared.html#optional",
@@ -779,7 +996,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 106,
+      id: 133,
       kind: 4194304,
       name: "Intersection",
       url: "modules/_tomato_js_shared.html#intersection",
@@ -787,7 +1004,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 107,
+      id: 134,
       kind: 4194304,
       name: "Diff",
       url: "modules/_tomato_js_shared.html#diff",
@@ -795,7 +1012,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 108,
+      id: 135,
       kind: 4194304,
       name: "$Keys",
       url: "modules/_tomato_js_shared.html#_keys",
@@ -803,7 +1020,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 109,
+      id: 136,
       kind: 4194304,
       name: "$Values",
       url: "modules/_tomato_js_shared.html#_values",
@@ -811,7 +1028,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 110,
+      id: 137,
       kind: 64,
       name: "isType",
       url: "modules/_tomato_js_shared.html#istype",
@@ -819,7 +1036,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 111,
+      id: 138,
       kind: 64,
       name: "isString",
       url: "modules/_tomato_js_shared.html#isstring",
@@ -827,7 +1044,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 112,
+      id: 139,
       kind: 64,
       name: "isNumber",
       url: "modules/_tomato_js_shared.html#isnumber",
@@ -835,7 +1052,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 113,
+      id: 140,
       kind: 64,
       name: "isArray",
       url: "modules/_tomato_js_shared.html#isarray",
@@ -843,7 +1060,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 114,
+      id: 141,
       kind: 64,
       name: "isObject",
       url: "modules/_tomato_js_shared.html#isobject",
@@ -851,7 +1068,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 115,
+      id: 142,
       kind: 64,
       name: "isFunction",
       url: "modules/_tomato_js_shared.html#isfunction",
@@ -859,7 +1076,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 116,
+      id: 143,
       kind: 64,
       name: "isNull",
       url: "modules/_tomato_js_shared.html#isnull",
@@ -867,7 +1084,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 117,
+      id: 144,
       kind: 64,
       name: "isUndefined",
       url: "modules/_tomato_js_shared.html#isundefined",
@@ -875,7 +1092,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 118,
+      id: 145,
       kind: 64,
       name: "isNil",
       url: "modules/_tomato_js_shared.html#isnil",
@@ -883,7 +1100,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 119,
+      id: 146,
       kind: 64,
       name: "isDef",
       url: "modules/_tomato_js_shared.html#isdef",
@@ -891,7 +1108,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 120,
+      id: 147,
       kind: 64,
       name: "isNumberLike",
       url: "modules/_tomato_js_shared.html#isnumberlike",
@@ -899,7 +1116,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 121,
+      id: 148,
       kind: 64,
       name: "isFalsy",
       url: "modules/_tomato_js_shared.html#isfalsy",
@@ -907,7 +1124,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 122,
+      id: 149,
       kind: 64,
       name: "forEach",
       url: "modules/_tomato_js_shared.html#foreach",
@@ -915,7 +1132,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 123,
+      id: 150,
       kind: 64,
       name: "isEmptyObject",
       url: "modules/_tomato_js_shared.html#isemptyobject",
@@ -923,7 +1140,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 124,
+      id: 151,
       kind: 64,
       name: "map",
       url: "modules/_tomato_js_shared.html#map",
@@ -931,7 +1148,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 125,
+      id: 152,
       kind: 64,
       name: "noop",
       url: "modules/_tomato_js_shared.html#noop",
@@ -939,7 +1156,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 126,
+      id: 153,
       kind: 64,
       name: "not",
       url: "modules/_tomato_js_shared.html#not",
@@ -947,7 +1164,7 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 127,
+      id: 154,
       kind: 32,
       name: "blankReg",
       url: "modules/_tomato_js_shared.html#blankreg",
@@ -955,16 +1172,16 @@ typedoc.search.data = {
       parent: "@tomato-js/shared"
     },
     {
-      id: 128,
+      id: 155,
       kind: 32,
       name: "asReg",
       url: "modules/_tomato_js_shared.html#asreg",
       classes: "tsd-kind-variable tsd-parent-kind-external-module",
       parent: "@tomato-js/shared"
     },
-    { id: 129, kind: 1, name: "@tomato-js/string", url: "modules/_tomato_js_string.html", classes: "tsd-kind-external-module" },
+    { id: 156, kind: 1, name: "@tomato-js/string", url: "modules/_tomato_js_string.html", classes: "tsd-kind-external-module" },
     {
-      id: 130,
+      id: 157,
       kind: 64,
       name: "camelCase",
       url: "modules/_tomato_js_string.html#camelcase",
@@ -972,7 +1189,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 131,
+      id: 158,
       kind: 64,
       name: "number2Chinese",
       url: "modules/_tomato_js_string.html#number2chinese",
@@ -980,7 +1197,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 132,
+      id: 159,
       kind: 64,
       name: "isJson",
       url: "modules/_tomato_js_string.html#isjson",
@@ -988,7 +1205,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 133,
+      id: 160,
       kind: 64,
       name: "kebabCase",
       url: "modules/_tomato_js_string.html#kebabcase",
@@ -996,7 +1213,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 134,
+      id: 161,
       kind: 64,
       name: "random",
       url: "modules/_tomato_js_string.html#random",
@@ -1004,7 +1221,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 135,
+      id: 162,
       kind: 64,
       name: "reverse",
       url: "modules/_tomato_js_string.html#reverse",
@@ -1012,7 +1229,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 136,
+      id: 163,
       kind: 64,
       name: "substringFromChar",
       url: "modules/_tomato_js_string.html#substringfromchar",
@@ -1020,7 +1237,7 @@ typedoc.search.data = {
       parent: "@tomato-js/string"
     },
     {
-      id: 137,
+      id: 164,
       kind: 64,
       name: "substringToChar",
       url: "modules/_tomato_js_string.html#substringtochar",

--- a/docs/classes/_tomato_js_async.pqueue.html
+++ b/docs/classes/_tomato_js_async.pqueue.html
@@ -1,0 +1,943 @@
+<!doctype html>
+<html class="default no-js">
+<head>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<title>PQueue | @tomato-js</title>
+	<meta name="description" content="">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<link rel="stylesheet" href="../assets/css/main.css">
+</head>
+<body>
+<header>
+	<div class="tsd-page-toolbar">
+		<div class="container">
+			<div class="table-wrap">
+				<div class="table-cell" id="tsd-search" data-index="../assets/js/search.js" data-base="..">
+					<div class="field">
+						<label for="tsd-search-field" class="tsd-widget search no-caption">Search</label>
+						<input id="tsd-search-field" type="text" />
+					</div>
+					<ul class="results">
+						<li class="state loading">Preparing search index...</li>
+						<li class="state failure">The search index is not available</li>
+					</ul>
+					<a href="../index.html" class="title">@tomato-js</a>
+				</div>
+				<div class="table-cell" id="tsd-widgets">
+					<div id="tsd-filter">
+						<a href="#" class="tsd-widget options no-caption" data-toggle="options">Options</a>
+						<div class="tsd-filter-group">
+							<div class="tsd-select" id="tsd-filter-visibility">
+								<span class="tsd-select-label">All</span>
+								<ul class="tsd-select-list">
+									<li data-value="public">Public</li>
+									<li data-value="protected">Public/Protected</li>
+									<li data-value="private" class="selected">All</li>
+								</ul>
+							</div>
+							<input type="checkbox" id="tsd-filter-inherited" checked />
+							<label class="tsd-widget" for="tsd-filter-inherited">Inherited</label>
+							<input type="checkbox" id="tsd-filter-externals" checked />
+							<label class="tsd-widget" for="tsd-filter-externals">Externals</label>
+						</div>
+					</div>
+					<a href="#" class="tsd-widget menu no-caption" data-toggle="menu">Menu</a>
+				</div>
+			</div>
+		</div>
+	</div>
+	<div class="tsd-page-title">
+		<div class="container">
+			<ul class="tsd-breadcrumb">
+				<li>
+					<a href="../globals.html">Globals</a>
+				</li>
+				<li>
+					<a href="../modules/_tomato_js_async.html">@tomato-js/async</a>
+				</li>
+				<li>
+					<a href="_tomato_js_async.pqueue.html">PQueue</a>
+				</li>
+			</ul>
+			<h1>Class PQueue</h1>
+		</div>
+	</div>
+</header>
+<div class="container container-main">
+	<div class="row">
+		<div class="col-8 col-content">
+			<section class="tsd-panel tsd-comment">
+				<div class="tsd-comment tsd-typography">
+					<div class="lead">
+						<p>函数描述</p>
+					</div>
+					<p>新增于v0.0.18</p>
+					<p>脚本举例</p>
+					<pre><code>  import { PQueue, sleep } from '@tomato-js/<span class="hljs-keyword">async</span>'
+  <span class="hljs-keyword">const</span> queue = new PQueue({
+    autoStart:<span class="hljs-literal">true</span>, <span class="hljs-comment">// 是否自动开始执行队列</span>
+    concurrency: <span class="hljs-number">1</span> <span class="hljs-comment">//队列执行并发数</span>
+  });
+  <span class="hljs-keyword">let</span> <span class="hljs-built_in">str</span> = <span class="hljs-string">""</span>;
+  queue.add(<span class="hljs-keyword">async</span> () =&gt; {
+    <span class="hljs-keyword">await</span> sleep(<span class="hljs-number">20</span>);
+    <span class="hljs-built_in">str</span> = <span class="hljs-built_in">str</span> + <span class="hljs-number">1</span>;
+  });
+  queue.add(<span class="hljs-keyword">async</span> () =&gt; {
+    <span class="hljs-keyword">await</span> sleep(<span class="hljs-number">30</span>);
+    <span class="hljs-built_in">str</span> = <span class="hljs-built_in">str</span> + <span class="hljs-number">2</span>;
+  });
+  queue.add(<span class="hljs-keyword">async</span> () =&gt; {
+    <span class="hljs-keyword">await</span> sleep(<span class="hljs-number">10</span>);
+    <span class="hljs-built_in">str</span> = <span class="hljs-built_in">str</span> + <span class="hljs-number">3</span>;
+  });
+  <span class="hljs-comment">// 同步方法监听</span>
+  <span class="hljs-keyword">await</span> queue.onIdle(()=&gt;<span class="hljs-built_in">str</span>)<span class="hljs-comment">//123;</span>
+  <span class="hljs-comment">// 通过事件监听</span>
+  queue.on(<span class="hljs-symbol">'idle</span>',()=&gt;<span class="hljs-built_in">str</span>)<span class="hljs-comment">//123</span></code></pre>
+				</div>
+			</section>
+			<section class="tsd-panel tsd-hierarchy">
+				<h3>Hierarchy</h3>
+				<ul class="tsd-hierarchy">
+					<li>
+						<span class="tsd-signature-type">Events</span>
+						<ul class="tsd-hierarchy">
+							<li>
+								<span class="target">PQueue</span>
+							</li>
+						</ul>
+					</li>
+				</ul>
+			</section>
+			<section class="tsd-panel-group tsd-index-group">
+				<h2>Index</h2>
+				<section class="tsd-panel tsd-index-panel">
+					<div class="tsd-index-content">
+						<section class="tsd-index-section ">
+							<h3>Constructors</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite"><a href="_tomato_js_async.pqueue.html#constructor" class="tsd-kind-icon">constructor</a></li>
+							</ul>
+						</section>
+						<section class="tsd-index-section ">
+							<h3>Properties</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#concurrency" class="tsd-kind-icon">concurrency</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class"><a href="_tomato_js_async.pqueue.html#ispaused" class="tsd-kind-icon">is<wbr>Paused</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#pendingcount" class="tsd-kind-icon">pending<wbr>Count</a></li>
+								<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#queue" class="tsd-kind-icon">queue</a></li>
+							</ul>
+						</section>
+						<section class="tsd-index-section ">
+							<h3>Accessors</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-get-signature tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#doesconcurrentallowanother" class="tsd-kind-icon">does<wbr>Concurrent<wbr>Allow<wbr>Another</a></li>
+								<li class="tsd-kind-get-signature tsd-parent-kind-class"><a href="_tomato_js_async.pqueue.html#pending" class="tsd-kind-icon">pending</a></li>
+							</ul>
+						</section>
+						<section class="tsd-index-section ">
+							<h3>Methods</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter"><a href="_tomato_js_async.pqueue.html#add" class="tsd-kind-icon">add</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter"><a href="_tomato_js_async.pqueue.html#addall" class="tsd-kind-icon">add<wbr>All</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#addeventlistener" class="tsd-kind-icon">add<wbr>Event<wbr>Listener</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_tomato_js_async.pqueue.html#clear" class="tsd-kind-icon">clear</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#clearall" class="tsd-kind-icon">clear<wbr>All</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#dequeue" class="tsd-kind-icon">dequeue</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#emit" class="tsd-kind-icon">emit</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#enqueue" class="tsd-kind-icon">enqueue</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#listeners" class="tsd-kind-icon">listeners</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#next" class="tsd-kind-icon">next</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#on" class="tsd-kind-icon">on</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_tomato_js_async.pqueue.html#onidle" class="tsd-kind-icon">on<wbr>Idle</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#once" class="tsd-kind-icon">once</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_tomato_js_async.pqueue.html#pause" class="tsd-kind-icon">pause</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#processqueue" class="tsd-kind-icon">process<wbr>Queue</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><a href="_tomato_js_async.pqueue.html#removelistener" class="tsd-kind-icon">remove<wbr>Listener</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-overwrite"><a href="_tomato_js_async.pqueue.html#size" class="tsd-kind-icon">size</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class"><a href="_tomato_js_async.pqueue.html#start" class="tsd-kind-icon">start</a></li>
+								<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><a href="_tomato_js_async.pqueue.html#trytostartanother" class="tsd-kind-icon">try<wbr>ToStart<wbr>Another</a></li>
+							</ul>
+						</section>
+					</div>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>Constructors</h2>
+				<section class="tsd-panel tsd-member tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
+					<a name="constructor" class="tsd-anchor"></a>
+					<h3>constructor</h3>
+					<ul class="tsd-signatures tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
+						<li class="tsd-signature tsd-kind-icon">new PQueue<span class="tsd-signature-symbol">(</span>options<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">Options</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><a href="_tomato_js_async.pqueue.html" class="tsd-signature-type">PQueue</a></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Overrides Events.__constructor</p>
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L56">async/src/p-queue.ts:56</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> options: <span class="tsd-signature-type">Options</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <a href="_tomato_js_async.pqueue.html" class="tsd-signature-type">PQueue</a></h4>
+						</li>
+					</ul>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>Properties</h2>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
+					<a name="concurrency" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> concurrency</h3>
+					<div class="tsd-signature tsd-kind-icon">concurrency<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L56">async/src/p-queue.ts:56</a></li>
+						</ul>
+					</aside>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class">
+					<a name="ispaused" class="tsd-anchor"></a>
+					<h3>is<wbr>Paused</h3>
+					<div class="tsd-signature tsd-kind-icon">is<wbr>Paused<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">boolean</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L53">async/src/p-queue.ts:53</a></li>
+						</ul>
+					</aside>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
+					<a name="pendingcount" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> pending<wbr>Count</h3>
+					<div class="tsd-signature tsd-kind-icon">pending<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span><span class="tsd-signature-symbol"> = 0</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L54">async/src/p-queue.ts:54</a></li>
+						</ul>
+					</aside>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-property tsd-parent-kind-class tsd-is-private">
+					<a name="queue" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> queue</h3>
+					<div class="tsd-signature tsd-kind-icon">queue<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Queue</span></div>
+					<aside class="tsd-sources">
+						<ul>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L55">async/src/p-queue.ts:55</a></li>
+						</ul>
+					</aside>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>Accessors</h2>
+				<section class="tsd-panel tsd-member tsd-kind-get-signature tsd-parent-kind-class tsd-is-private">
+					<a name="doesconcurrentallowanother" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> does<wbr>Concurrent<wbr>Allow<wbr>Another</h3>
+					<ul class="tsd-signatures tsd-kind-get-signature tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> doesConcurrentAllowAnother<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L68">async/src/p-queue.ts:68</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-get-signature tsd-parent-kind-class">
+					<a name="pending" class="tsd-anchor"></a>
+					<h3>pending</h3>
+					<ul class="tsd-signatures tsd-kind-get-signature tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">get</span> pending<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L152">async/src/p-queue.ts:152</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
+						</li>
+					</ul>
+				</section>
+			</section>
+			<section class="tsd-panel-group tsd-member-group ">
+				<h2>Methods</h2>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+					<a name="add" class="tsd-anchor"></a>
+					<h3>add</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+						<li class="tsd-signature tsd-kind-icon">add&lt;TaskResultsType&gt;<span class="tsd-signature-symbol">(</span>fn<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Task</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L117">async/src/p-queue.ts:117</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-type-parameters-title">Type parameters</h4>
+							<ul class="tsd-type-parameters">
+								<li>
+									<h4>TaskResultsType</h4>
+								</li>
+							</ul>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>fn: <span class="tsd-signature-type">Task</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+					<a name="addall" class="tsd-anchor"></a>
+					<h3>add<wbr>All</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+						<li class="tsd-signature tsd-kind-icon">add<wbr>All&lt;TaskResultsType&gt;<span class="tsd-signature-symbol">(</span>fns<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">ReadonlyArray</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Task</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L136">async/src/p-queue.ts:136</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-type-parameters-title">Type parameters</h4>
+							<ul class="tsd-type-parameters">
+								<li>
+									<h4>TaskResultsType</h4>
+								</li>
+							</ul>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>fns: <span class="tsd-signature-type">ReadonlyArray</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Task</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">TaskResultsType</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">&gt;</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="addeventlistener" class="tsd-anchor"></a>
+					<h3>add<wbr>Event<wbr>Listener</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">add<wbr>Event<wbr>Listener<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fn<span class="tsd-signature-symbol">: </span><a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a>, context<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">unknown</span>, once<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#addeventlistener">addEventListener</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:33</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+								<li>
+									<h5>fn: <a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a></h5>
+								</li>
+								<li>
+									<h5>context: <span class="tsd-signature-type">unknown</span></h5>
+								</li>
+								<li>
+									<h5>once: <span class="tsd-signature-type">boolean</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+					<a name="clear" class="tsd-anchor"></a>
+					<h3>clear</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+						<li class="tsd-signature tsd-kind-icon">clear<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Overrides Events.clear</p>
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L144">async/src/p-queue.ts:144</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="clearall" class="tsd-anchor"></a>
+					<h3>clear<wbr>All</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">clear<wbr>All<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#clearall">clearAll</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:38</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
+					<a name="dequeue" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> dequeue</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon">dequeue<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L95">async/src/p-queue.ts:95</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">)</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="emit" class="tsd-anchor"></a>
+					<h3>emit</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">emit<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, <span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#emit">emit</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:35</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagRest">Rest</span> <span class="tsd-signature-symbol">...</span>args: <span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">[]</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
+					<a name="enqueue" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> enqueue</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon">enqueue<span class="tsd-signature-symbol">(</span>__namedParameters<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">{ </span>run<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L92">async/src/p-queue.ts:92</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>__namedParameters: <span class="tsd-signature-symbol">{ </span>run<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> }</span></h5>
+									<ul class="tsd-parameters">
+										<li class="tsd-parameter">
+											<h5>run<span class="tsd-signature-symbol">: </span><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span></h5>
+											<ul class="tsd-parameters">
+												<li class="tsd-parameter-siganture">
+													<ul class="tsd-signatures tsd-kind-type-literal tsd-parent-kind-variable">
+														<li class="tsd-signature tsd-kind-icon"><span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span></li>
+													</ul>
+													<ul class="tsd-descriptions">
+														<li class="tsd-description">
+															<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span></h4>
+														</li>
+													</ul>
+												</li>
+											</ul>
+										</li>
+									</ul>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="listeners" class="tsd-anchor"></a>
+					<h3>listeners</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">listeners<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Listeners</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#listeners">listeners</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:36</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Listeners</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
+					<a name="next" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> next</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon">next<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L88">async/src/p-queue.ts:88</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="on" class="tsd-anchor"></a>
+					<h3>on</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">on<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fn<span class="tsd-signature-symbol">: </span><a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a>, context<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#on">on</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:31</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+								<li>
+									<h5>fn: <a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a></h5>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> context: <span class="tsd-signature-type">unknown</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
+					<a name="onidle" class="tsd-anchor"></a>
+					<h3>on<wbr>Idle</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon">on<wbr>Idle<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L139">async/src/p-queue.ts:139</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">Promise</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">&gt;</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="once" class="tsd-anchor"></a>
+					<h3>once</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">once<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span>, fn<span class="tsd-signature-symbol">: </span><a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a>, context<span class="tsd-signature-symbol">?: </span><span class="tsd-signature-type">unknown</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#once">once</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:32</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+								<li>
+									<h5>fn: <a href="../modules/_tomato_js_shared.html#functiontype" class="tsd-signature-type">FunctionType</a></h5>
+								</li>
+								<li>
+									<h5><span class="tsd-flag ts-flagOptional">Optional</span> context: <span class="tsd-signature-type">unknown</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
+					<a name="pause" class="tsd-anchor"></a>
+					<h3>pause</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon">pause<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L114">async/src/p-queue.ts:114</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
+					<a name="processqueue" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> process<wbr>Queue</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon">process<wbr>Queue<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">void</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L100">async/src/p-queue.ts:100</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+					<a name="removelistener" class="tsd-anchor"></a>
+					<h3>remove<wbr>Listener</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+						<li class="tsd-signature tsd-kind-icon">remove<wbr>Listener<span class="tsd-signature-symbol">(</span>event<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Inherited from <a href="_tomato_js_async.pqueue.html">PQueue</a>.<a href="_tomato_js_async.pqueue.html#removelistener">removeListener</a></p>
+								<ul>
+									<li>Defined in events/dist/lib/Events.d.ts:34</li>
+								</ul>
+							</aside>
+							<h4 class="tsd-parameters-title">Parameters</h4>
+							<ul class="tsd-parameters">
+								<li>
+									<h5>event: <span class="tsd-signature-type">string</span></h5>
+								</li>
+							</ul>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+					<a name="size" class="tsd-anchor"></a>
+					<h3>size</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+						<li class="tsd-signature tsd-kind-icon">size<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">number</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<p>Overrides Events.size</p>
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L149">async/src/p-queue.ts:149</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class">
+					<a name="start" class="tsd-anchor"></a>
+					<h3>start</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class">
+						<li class="tsd-signature tsd-kind-icon">start<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">this</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L103">async/src/p-queue.ts:103</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">this</span></h4>
+						</li>
+					</ul>
+				</section>
+				<section class="tsd-panel tsd-member tsd-kind-method tsd-parent-kind-class tsd-is-private">
+					<a name="trytostartanother" class="tsd-anchor"></a>
+					<h3><span class="tsd-flag ts-flagPrivate">Private</span> try<wbr>ToStart<wbr>Another</h3>
+					<ul class="tsd-signatures tsd-kind-method tsd-parent-kind-class tsd-is-private">
+						<li class="tsd-signature tsd-kind-icon">try<wbr>ToStart<wbr>Another<span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">boolean</span></li>
+					</ul>
+					<ul class="tsd-descriptions">
+						<li class="tsd-description">
+							<aside class="tsd-sources">
+								<ul>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-queue.ts#L71">async/src/p-queue.ts:71</a></li>
+								</ul>
+							</aside>
+							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">boolean</span></h4>
+						</li>
+					</ul>
+				</section>
+			</section>
+		</div>
+		<div class="col-4 col-menu menu-sticky-wrap menu-highlight">
+			<nav class="tsd-navigation primary">
+				<ul>
+					<li class="globals  ">
+						<a href="../globals.html"><em>Globals</em></a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_array.html">@tomato-<wbr>js/array</a>
+					</li>
+					<li class="current tsd-kind-external-module">
+						<a href="../modules/_tomato_js_async.html">@tomato-<wbr>js/async</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_cookie.html">@tomato-<wbr>js/cookie</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_element.html">@tomato-<wbr>js/element</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_env.html">@tomato-<wbr>js/env</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_events.html">@tomato-<wbr>js/events</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_function.html">@tomato-<wbr>js/function</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_math.html">@tomato-<wbr>js/math</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_object.html">@tomato-<wbr>js/object</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_path.html">@tomato-<wbr>js/path</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_queue.html">@tomato-<wbr>js/queue</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_shared.html">@tomato-<wbr>js/shared</a>
+					</li>
+					<li class=" tsd-kind-external-module">
+						<a href="../modules/_tomato_js_string.html">@tomato-<wbr>js/string</a>
+					</li>
+				</ul>
+			</nav>
+			<nav class="tsd-navigation secondary menu-sticky">
+				<ul class="before-current">
+				</ul>
+				<ul class="current">
+					<li class="current tsd-kind-class tsd-parent-kind-external-module">
+						<a href="_tomato_js_async.pqueue.html" class="tsd-kind-icon">PQueue</a>
+						<ul>
+							<li class=" tsd-kind-constructor tsd-parent-kind-class tsd-is-overwrite">
+								<a href="_tomato_js_async.pqueue.html#constructor" class="tsd-kind-icon">constructor</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#concurrency" class="tsd-kind-icon">concurrency</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class">
+								<a href="_tomato_js_async.pqueue.html#ispaused" class="tsd-kind-icon">is<wbr>Paused</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#pendingcount" class="tsd-kind-icon">pending<wbr>Count</a>
+							</li>
+							<li class=" tsd-kind-property tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#queue" class="tsd-kind-icon">queue</a>
+							</li>
+							<li class=" tsd-kind-get-signature tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#doesconcurrentallowanother" class="tsd-kind-icon">does<wbr>Concurrent<wbr>Allow<wbr>Another</a>
+							</li>
+							<li class=" tsd-kind-get-signature tsd-parent-kind-class">
+								<a href="_tomato_js_async.pqueue.html#pending" class="tsd-kind-icon">pending</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+								<a href="_tomato_js_async.pqueue.html#add" class="tsd-kind-icon">add</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-has-type-parameter">
+								<a href="_tomato_js_async.pqueue.html#addall" class="tsd-kind-icon">add<wbr>All</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#addeventlistener" class="tsd-kind-icon">add<wbr>Event<wbr>Listener</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+								<a href="_tomato_js_async.pqueue.html#clear" class="tsd-kind-icon">clear</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#clearall" class="tsd-kind-icon">clear<wbr>All</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#dequeue" class="tsd-kind-icon">dequeue</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#emit" class="tsd-kind-icon">emit</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#enqueue" class="tsd-kind-icon">enqueue</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#listeners" class="tsd-kind-icon">listeners</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#next" class="tsd-kind-icon">next</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#on" class="tsd-kind-icon">on</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class">
+								<a href="_tomato_js_async.pqueue.html#onidle" class="tsd-kind-icon">on<wbr>Idle</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#once" class="tsd-kind-icon">once</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class">
+								<a href="_tomato_js_async.pqueue.html#pause" class="tsd-kind-icon">pause</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#processqueue" class="tsd-kind-icon">process<wbr>Queue</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-inherited">
+								<a href="_tomato_js_async.pqueue.html#removelistener" class="tsd-kind-icon">remove<wbr>Listener</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-overwrite">
+								<a href="_tomato_js_async.pqueue.html#size" class="tsd-kind-icon">size</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class">
+								<a href="_tomato_js_async.pqueue.html#start" class="tsd-kind-icon">start</a>
+							</li>
+							<li class=" tsd-kind-method tsd-parent-kind-class tsd-is-private">
+								<a href="_tomato_js_async.pqueue.html#trytostartanother" class="tsd-kind-icon">try<wbr>ToStart<wbr>Another</a>
+							</li>
+						</ul>
+					</li>
+				</ul>
+				<ul class="after-current">
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
+						<a href="../modules/_tomato_js_async.html#callbackify" class="tsd-kind-icon">callbackify</a>
+					</li>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
+						<a href="../modules/_tomato_js_async.html#pif" class="tsd-kind-icon">p<wbr>If</a>
+					</li>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
+						<a href="../modules/_tomato_js_async.html#plog" class="tsd-kind-icon">p<wbr>Log</a>
+					</li>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module tsd-has-type-parameter">
+						<a href="../modules/_tomato_js_async.html#ptap" class="tsd-kind-icon">p<wbr>Tap</a>
+					</li>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
+						<a href="../modules/_tomato_js_async.html#promisify" class="tsd-kind-icon">promisify</a>
+					</li>
+					<li class=" tsd-kind-function tsd-parent-kind-external-module">
+						<a href="../modules/_tomato_js_async.html#sleep" class="tsd-kind-icon">sleep</a>
+					</li>
+				</ul>
+			</nav>
+		</div>
+	</div>
+</div>
+<footer class="with-border-bottom">
+	<div class="container">
+		<h2>Legend</h2>
+		<div class="tsd-legend-group">
+			<ul class="tsd-legend">
+				<li class="tsd-kind-module"><span class="tsd-kind-icon">Module</span></li>
+				<li class="tsd-kind-object-literal"><span class="tsd-kind-icon">Object literal</span></li>
+				<li class="tsd-kind-variable"><span class="tsd-kind-icon">Variable</span></li>
+				<li class="tsd-kind-function"><span class="tsd-kind-icon">Function</span></li>
+				<li class="tsd-kind-function tsd-has-type-parameter"><span class="tsd-kind-icon">Function with type parameter</span></li>
+				<li class="tsd-kind-index-signature"><span class="tsd-kind-icon">Index signature</span></li>
+				<li class="tsd-kind-type-alias"><span class="tsd-kind-icon">Type alias</span></li>
+				<li class="tsd-kind-type-alias tsd-has-type-parameter"><span class="tsd-kind-icon">Type alias with type parameter</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-enum"><span class="tsd-kind-icon">Enumeration</span></li>
+				<li class="tsd-kind-enum-member"><span class="tsd-kind-icon">Enumeration member</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-enum"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-enum"><span class="tsd-kind-icon">Method</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-interface"><span class="tsd-kind-icon">Interface</span></li>
+				<li class="tsd-kind-interface tsd-has-type-parameter"><span class="tsd-kind-icon">Interface with type parameter</span></li>
+				<li class="tsd-kind-constructor tsd-parent-kind-interface"><span class="tsd-kind-icon">Constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-interface"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-interface"><span class="tsd-kind-icon">Method</span></li>
+				<li class="tsd-kind-index-signature tsd-parent-kind-interface"><span class="tsd-kind-icon">Index signature</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-class"><span class="tsd-kind-icon">Class</span></li>
+				<li class="tsd-kind-class tsd-has-type-parameter"><span class="tsd-kind-icon">Class with type parameter</span></li>
+				<li class="tsd-kind-constructor tsd-parent-kind-class"><span class="tsd-kind-icon">Constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-class"><span class="tsd-kind-icon">Property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class"><span class="tsd-kind-icon">Method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class"><span class="tsd-kind-icon">Accessor</span></li>
+				<li class="tsd-kind-index-signature tsd-parent-kind-class"><span class="tsd-kind-icon">Index signature</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-constructor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited constructor</span></li>
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-inherited"><span class="tsd-kind-icon">Inherited accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-protected"><span class="tsd-kind-icon">Protected accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private property</span></li>
+				<li class="tsd-kind-method tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private method</span></li>
+				<li class="tsd-kind-accessor tsd-parent-kind-class tsd-is-private"><span class="tsd-kind-icon">Private accessor</span></li>
+			</ul>
+			<ul class="tsd-legend">
+				<li class="tsd-kind-property tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static property</span></li>
+				<li class="tsd-kind-call-signature tsd-parent-kind-class tsd-is-static"><span class="tsd-kind-icon">Static method</span></li>
+			</ul>
+		</div>
+	</div>
+</footer>
+<div class="container tsd-generator">
+	<p>Generated using <a href="https://typedoc.org/" target="_blank">TypeDoc</a></p>
+</div>
+<div class="overlay"></div>
+<script src="../assets/js/main.js"></script>
+<script>if (location.protocol == 'file:') document.write('<script src="../assets/js/search.js"><' + '/script>');</script>
+</body>
+</html>

--- a/docs/classes/_tomato_js_events.events.html
+++ b/docs/classes/_tomato_js_events.events.html
@@ -136,7 +136,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L30">events/src/Events.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L30">events/src/Events.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <a href="_tomato_js_events.events.html" class="tsd-signature-type">Events</a></h4>
@@ -152,7 +152,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Map</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">string</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Listeners</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L29">events/src/Events.ts:29</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L29">events/src/Events.ts:29</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -162,7 +162,7 @@
 					<div class="tsd-signature tsd-kind-icon">events<wbr>Count<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">number</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L30">events/src/Events.ts:30</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L30">events/src/Events.ts:30</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L41">events/src/Events.ts:41</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L41">events/src/Events.ts:41</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -211,7 +211,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L76">events/src/Events.ts:76</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L76">events/src/Events.ts:76</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -234,7 +234,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L84">events/src/Events.ts:84</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L84">events/src/Events.ts:84</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">void</span></h4>
@@ -251,7 +251,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L61">events/src/Events.ts:61</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L61">events/src/Events.ts:61</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -277,7 +277,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L73">events/src/Events.ts:73</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L73">events/src/Events.ts:73</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -300,7 +300,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L35">events/src/Events.ts:35</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L35">events/src/Events.ts:35</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -329,7 +329,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L38">events/src/Events.ts:38</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L38">events/src/Events.ts:38</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L54">events/src/Events.ts:54</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L54">events/src/Events.ts:54</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -381,7 +381,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/events/src/Events.ts#L87">events/src/Events.ts:87</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/events/src/Events.ts#L87">events/src/Events.ts:87</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-returns-title">Returns <span class="tsd-signature-type">number</span></h4>

--- a/docs/modules/_tomato_js_array.html
+++ b/docs/modules/_tomato_js_array.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/all-equal.ts#L18">array/src/all-equal.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/all-equal.ts#L18">array/src/all-equal.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -137,7 +137,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/count-occurrences.ts#L20">array/src/count-occurrences.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/count-occurrences.ts#L20">array/src/count-occurrences.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -179,7 +179,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/deep-flatten.ts#L18">array/src/deep-flatten.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/deep-flatten.ts#L18">array/src/deep-flatten.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/filter-non-unique.ts#L17">array/src/filter-non-unique.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/filter-non-unique.ts#L17">array/src/filter-non-unique.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -249,7 +249,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/find.ts#L20">array/src/find.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/find.ts#L20">array/src/find.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -287,7 +287,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/sample.ts#L20">array/src/sample.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/sample.ts#L20">array/src/sample.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -319,7 +319,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/sample-size.ts#L20">array/src/sample-size.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/sample-size.ts#L20">array/src/sample-size.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -360,7 +360,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/union.ts#L18">array/src/union.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/union.ts#L18">array/src/union.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -386,7 +386,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/union.ts#L19">array/src/union.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/union.ts#L19">array/src/union.ts:19</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -403,7 +403,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/array/src/union.ts#L20">array/src/union.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/array/src/union.ts#L20">array/src/union.ts:20</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>

--- a/docs/modules/_tomato_js_async.html
+++ b/docs/modules/_tomato_js_async.html
@@ -69,6 +69,12 @@
 				<section class="tsd-panel tsd-index-panel">
 					<div class="tsd-index-content">
 						<section class="tsd-index-section ">
+							<h3>Classes</h3>
+							<ul class="tsd-index-list">
+								<li class="tsd-kind-class tsd-parent-kind-external-module"><a href="../classes/_tomato_js_async.pqueue.html" class="tsd-kind-icon">PQueue</a></li>
+							</ul>
+						</section>
+						<section class="tsd-index-section ">
 							<h3>Functions</h3>
 							<ul class="tsd-index-list">
 								<li class="tsd-kind-function tsd-parent-kind-external-module"><a href="_tomato_js_async.html#callbackify" class="tsd-kind-icon">callbackify</a></li>
@@ -94,7 +100,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/callbackify.ts#L24">async/src/callbackify.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/callbackify.ts#L24">async/src/callbackify.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -135,7 +141,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/p-if.ts#L25">async/src/p-if.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-if.ts#L25">async/src/p-if.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +220,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/p-log.ts#L26">async/src/p-log.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-log.ts#L26">async/src/p-log.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -278,7 +284,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/p-tap.ts#L25">async/src/p-tap.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/p-tap.ts#L25">async/src/p-tap.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -342,7 +348,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/promisify.ts#L19">async/src/promisify.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/promisify.ts#L19">async/src/promisify.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -378,7 +384,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/async/src/sleep.ts#L24">async/src/sleep.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/async/src/sleep.ts#L24">async/src/sleep.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -461,6 +467,9 @@
 			</nav>
 			<nav class="tsd-navigation secondary menu-sticky">
 				<ul class="before-current">
+					<li class=" tsd-kind-class tsd-parent-kind-external-module">
+						<a href="../classes/_tomato_js_async.pqueue.html" class="tsd-kind-icon">PQueue</a>
+					</li>
 					<li class=" tsd-kind-function tsd-parent-kind-external-module">
 						<a href="_tomato_js_async.html#callbackify" class="tsd-kind-icon">callbackify</a>
 					</li>

--- a/docs/modules/_tomato_js_cookie.html
+++ b/docs/modules/_tomato_js_cookie.html
@@ -92,7 +92,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/cookie/src/get.ts#L19">cookie/src/get.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/cookie/src/get.ts#L19">cookie/src/get.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -133,7 +133,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/cookie/src/has.ts#L19">cookie/src/has.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/cookie/src/has.ts#L19">cookie/src/has.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -174,7 +174,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/cookie/src/remove.ts#L26">cookie/src/remove.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/cookie/src/remove.ts#L26">cookie/src/remove.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -215,7 +215,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/cookie/src/set.ts#L32">cookie/src/set.ts:32</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/cookie/src/set.ts#L32">cookie/src/set.ts:32</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_element.html
+++ b/docs/modules/_tomato_js_element.html
@@ -97,7 +97,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/addStyle.ts#L28">element/src/addStyle.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/addStyle.ts#L28">element/src/addStyle.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -138,7 +138,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/insert.ts#L47">element/src/insert.ts:47</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/insert.ts#L47">element/src/insert.ts:47</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -180,7 +180,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/bottom-visible.ts#L18">element/src/bottom-visible.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/bottom-visible.ts#L18">element/src/bottom-visible.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -206,7 +206,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/create.ts#L27">element/src/create.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/create.ts#L27">element/src/create.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -256,7 +256,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/get.ts#L26">element/src/get.ts:26</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/get.ts#L26">element/src/get.ts:26</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -295,7 +295,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/insert.ts#L98">element/src/insert.ts:98</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/insert.ts#L98">element/src/insert.ts:98</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -337,7 +337,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/insert.ts#L81">element/src/insert.ts:81</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/insert.ts#L81">element/src/insert.ts:81</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -379,7 +379,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/insert.ts#L64">element/src/insert.ts:64</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/insert.ts#L64">element/src/insert.ts:64</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -421,7 +421,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/element/src/scroll-to-top.ts#L18">element/src/scroll-to-top.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/element/src/scroll-to-top.ts#L18">element/src/scroll-to-top.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_env.html
+++ b/docs/modules/_tomato_js_env.html
@@ -91,7 +91,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/env/src/is-browser.ts#L17">env/src/is-browser.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/env/src/is-browser.ts#L17">env/src/is-browser.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -117,7 +117,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/env/src/judge.ts#L18">env/src/judge.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/env/src/judge.ts#L18">env/src/judge.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/env/src/judge.ts#L30">env/src/judge.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/env/src/judge.ts#L30">env/src/judge.ts:30</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_function.html
+++ b/docs/modules/_tomato_js_function.html
@@ -108,7 +108,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/after.ts#L23">function/src/after.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/after.ts#L23">function/src/after.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -152,7 +152,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/after-return.ts#L23">function/src/after-return.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/after-return.ts#L23">function/src/after-return.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -196,7 +196,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/aop.ts#L37">function/src/aop.ts:37</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/aop.ts#L37">function/src/aop.ts:37</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -246,7 +246,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/around.ts#L23">function/src/around.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/around.ts#L23">function/src/around.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -290,7 +290,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/before.ts#L23">function/src/before.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/before.ts#L23">function/src/before.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -335,7 +335,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/both.ts#L23">function/src/both.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/both.ts#L23">function/src/both.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -365,7 +365,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/both.ts#L24">function/src/both.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/both.ts#L24">function/src/both.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -388,7 +388,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/compose.ts#L23">function/src/compose.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/compose.ts#L23">function/src/compose.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -428,7 +428,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/curry.ts#L25">function/src/curry.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/curry.ts#L25">function/src/curry.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -475,7 +475,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/debounce.ts#L27">function/src/debounce.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/debounce.ts#L27">function/src/debounce.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -551,7 +551,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/either.ts#L23">function/src/either.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/either.ts#L23">function/src/either.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -581,7 +581,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/either.ts#L24">function/src/either.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/either.ts#L24">function/src/either.ts:24</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -604,7 +604,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/flip.ts#L23">function/src/flip.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/flip.ts#L23">function/src/flip.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -644,7 +644,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/inverse.ts#L23">function/src/inverse.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/inverse.ts#L23">function/src/inverse.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -682,7 +682,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/once.ts#L22">function/src/once.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/once.ts#L22">function/src/once.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -739,7 +739,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/partial.ts#L25">function/src/partial.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/partial.ts#L25">function/src/partial.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -785,7 +785,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/partial-right.ts#L25">function/src/partial-right.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/partial-right.ts#L25">function/src/partial-right.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -831,7 +831,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/pipe.ts#L24">function/src/pipe.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/pipe.ts#L24">function/src/pipe.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -871,7 +871,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/poll.ts#L40">function/src/poll.ts:40</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/poll.ts#L40">function/src/poll.ts:40</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -992,7 +992,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/take-time.ts#L18">function/src/take-time.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/take-time.ts#L18">function/src/take-time.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1027,7 +1027,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/throttle.ts#L27">function/src/throttle.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/throttle.ts#L27">function/src/throttle.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1099,7 +1099,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/function/src/times.ts#L20">function/src/times.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/function/src/times.ts#L20">function/src/times.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_math.html
+++ b/docs/modules/_tomato_js_math.html
@@ -97,7 +97,7 @@
 					<div class="tsd-signature tsd-kind-icon">add<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = curry((num1: number, num2: number) &#x3D;&gt; {return Number(num1) + Number(num2);})</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/add.ts#L23">math/src/add.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/add.ts#L23">math/src/add.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 					<div class="tsd-signature tsd-kind-icon">divide<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = curry((num1: number, num2: number) &#x3D;&gt; {return Number(num1) / Number(num2);})</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/divide.ts#L23">math/src/divide.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/divide.ts#L23">math/src/divide.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -159,7 +159,7 @@
 					<div class="tsd-signature tsd-kind-icon">multiply<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = curry((num1: number, num2: number) &#x3D;&gt; {return Number(num1) * Number(num2);})</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/multiply.ts#L23">math/src/multiply.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/multiply.ts#L23">math/src/multiply.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -190,7 +190,7 @@
 					<div class="tsd-signature tsd-kind-icon">subtract<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">any</span><span class="tsd-signature-symbol"> = curry((num1: number, num2: number) &#x3D;&gt; {return Number(num1) - Number(num2);})</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/subtract.ts#L23">math/src/subtract.ts:23</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/subtract.ts#L23">math/src/subtract.ts:23</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -228,7 +228,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/average.ts#L19">math/src/average.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/average.ts#L19">math/src/average.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -264,7 +264,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/average-by.ts#L19">math/src/average-by.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/average-by.ts#L19">math/src/average-by.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -323,7 +323,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/sum.ts#L19">math/src/sum.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/sum.ts#L19">math/src/sum.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -359,7 +359,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/math/src/sum-by.ts#L19">math/src/sum-by.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/math/src/sum-by.ts#L19">math/src/sum-by.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_object.html
+++ b/docs/modules/_tomato_js_object.html
@@ -93,7 +93,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/object/src/deep-clone.ts#L22">object/src/deep-clone.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/object/src/deep-clone.ts#L22">object/src/deep-clone.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -130,7 +130,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/object/src/deep-get.ts#L23">object/src/deep-get.ts:23</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/object/src/deep-get.ts#L23">object/src/deep-get.ts:23</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -172,7 +172,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/object/src/lazy.ts#L24">object/src/lazy.ts:24</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/object/src/lazy.ts#L24">object/src/lazy.ts:24</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -214,7 +214,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/object/src/pick.ts#L27">object/src/pick.ts:27</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/object/src/pick.ts#L27">object/src/pick.ts:27</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -267,7 +267,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/object/src/pick-x.ts#L48">object/src/pick-x.ts:48</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/object/src/pick-x.ts#L48">object/src/pick-x.ts:48</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_path.html
+++ b/docs/modules/_tomato_js_path.html
@@ -92,7 +92,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/path/src/parse.ts#L29">path/src/parse.ts:29</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/path/src/parse.ts#L29">path/src/parse.ts:29</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -128,7 +128,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/path/src/merge.ts#L22">path/src/merge.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/path/src/merge.ts#L22">path/src/merge.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -170,7 +170,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/path/src/parse.ts#L71">path/src/parse.ts:71</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/path/src/parse.ts#L71">path/src/parse.ts:71</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -213,7 +213,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/path/src/stringify.ts#L28">path/src/stringify.ts:28</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/path/src/stringify.ts#L28">path/src/stringify.ts:28</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_queue.html
+++ b/docs/modules/_tomato_js_queue.html
@@ -89,7 +89,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/queue/src/chainer.ts#L31">queue/src/chainer.ts:31</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/queue/src/chainer.ts#L31">queue/src/chainer.ts:31</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_shared.html
+++ b/docs/modules/_tomato_js_shared.html
@@ -134,7 +134,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<wbr>Keys&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L155">shared/src/types.ts:155</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L155">shared/src/types.ts:155</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -161,7 +161,7 @@
 					<div class="tsd-signature tsd-kind-icon">$<wbr>Values&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L171">shared/src/types.ts:171</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L171">shared/src/types.ts:171</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -188,7 +188,7 @@
 					<div class="tsd-signature tsd-kind-icon">Diff&lt;T, U&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Exclude</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L139">shared/src/types.ts:139</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L139">shared/src/types.ts:139</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -219,7 +219,7 @@
 					<div class="tsd-signature tsd-kind-icon">Eachable&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol"> | </span><a href="../interfaces/_tomato_js_shared.objecttype.html" class="tsd-signature-type">ObjectType</a><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L10">shared/src/types.ts:10</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L10">shared/src/types.ts:10</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -235,7 +235,7 @@
 					<div class="tsd-signature tsd-kind-icon">Falsy<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">false</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">""</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">0</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">null</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">undefined</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L14">shared/src/types.ts:14</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L14">shared/src/types.ts:14</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -245,7 +245,7 @@
 					<div class="tsd-signature tsd-kind-icon">Function<wbr>Keys&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L32">shared/src/types.ts:32</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L32">shared/src/types.ts:32</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -272,7 +272,7 @@
 					<div class="tsd-signature tsd-kind-icon">Function<wbr>Type&lt;T, U&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">(</span><span class="tsd-signature-symbol">...</span>args<span class="tsd-signature-symbol">: </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">[]</span><span class="tsd-signature-symbol">)</span><span class="tsd-signature-symbol"> =&gt; </span><span class="tsd-signature-type">U</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L12">shared/src/types.ts:12</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L12">shared/src/types.ts:12</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -312,7 +312,7 @@
 					<div class="tsd-signature tsd-kind-icon">HTMLElement<wbr>Key<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">HTMLElementTagNameMap</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L8">shared/src/types.ts:8</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L8">shared/src/types.ts:8</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -322,7 +322,7 @@
 					<div class="tsd-signature tsd-kind-icon">HTMLSelector<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">string</span><span class="tsd-signature-symbol"> | </span><span class="tsd-signature-type">HTMLElement</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L6">shared/src/types.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L6">shared/src/types.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -332,7 +332,7 @@
 					<div class="tsd-signature tsd-kind-icon">Intersection&lt;T, U&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">Extract</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol"> &amp; </span><span class="tsd-signature-type">Extract</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">U</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L123">shared/src/types.ts:123</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L123">shared/src/types.ts:123</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -363,7 +363,7 @@
 					<div class="tsd-signature tsd-kind-icon">Non<wbr>Function<wbr>Keys&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L50">shared/src/types.ts:50</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L50">shared/src/types.ts:50</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -390,7 +390,7 @@
 					<div class="tsd-signature tsd-kind-icon">Non<wbr>Undefined&lt;A&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">A</span><span class="tsd-signature-symbol"> extends </span><span class="tsd-signature-type">undefined</span><span class="tsd-signature-symbol"> ? </span><span class="tsd-signature-type">never</span><span class="tsd-signature-symbol"> : </span><span class="tsd-signature-type">A</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L16">shared/src/types.ts:16</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L16">shared/src/types.ts:16</a></li>
 						</ul>
 					</aside>
 					<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -406,7 +406,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional&lt;T, K&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">Partial</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">Pick</span><span class="tsd-signature-symbol">&lt;</span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">, </span><span class="tsd-signature-type">K</span><span class="tsd-signature-symbol">&gt;</span><span class="tsd-signature-symbol">&gt;</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L106">shared/src/types.ts:106</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L106">shared/src/types.ts:106</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -438,7 +438,7 @@
 					<div class="tsd-signature tsd-kind-icon">Optional<wbr>Keys&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L86">shared/src/types.ts:86</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L86">shared/src/types.ts:86</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -465,7 +465,7 @@
 					<div class="tsd-signature tsd-kind-icon">Required<wbr>Keys&lt;T&gt;<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-symbol">{}</span><span class="tsd-signature-symbol">[</span><span class="tsd-signature-symbol">keyof </span><span class="tsd-signature-type">T</span><span class="tsd-signature-symbol">]</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/types.ts#L68">shared/src/types.ts:68</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/types.ts#L68">shared/src/types.ts:68</a></li>
 						</ul>
 					</aside>
 					<div class="tsd-comment tsd-typography">
@@ -495,7 +495,7 @@
 					<div class="tsd-signature tsd-kind-icon">as<wbr>Reg<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /(.+)\sas\s(.+)/gi</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/regexp.ts#L6">shared/src/regexp.ts:6</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/regexp.ts#L6">shared/src/regexp.ts:6</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -505,7 +505,7 @@
 					<div class="tsd-signature tsd-kind-icon">blank<wbr>Reg<span class="tsd-signature-symbol">:</span> <span class="tsd-signature-type">RegExp</span><span class="tsd-signature-symbol"> = /[\s\r\n]+/gi</span></div>
 					<aside class="tsd-sources">
 						<ul>
-							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/regexp.ts#L5">shared/src/regexp.ts:5</a></li>
+							<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/regexp.ts#L5">shared/src/regexp.ts:5</a></li>
 						</ul>
 					</aside>
 				</section>
@@ -522,7 +522,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/for-each.ts#L49">shared/src/for-each.ts:49</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/for-each.ts#L49">shared/src/for-each.ts:49</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -590,7 +590,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L21">shared/src/is-type.ts:21</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L21">shared/src/is-type.ts:21</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -613,7 +613,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L96">shared/src/is-type.ts:96</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L96">shared/src/is-type.ts:96</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -649,7 +649,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-empty.ts#L17">shared/src/is-empty.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-empty.ts#L17">shared/src/is-empty.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -684,7 +684,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L129">shared/src/is-type.ts:129</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L129">shared/src/is-type.ts:129</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -720,7 +720,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L30">shared/src/is-type.ts:30</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L30">shared/src/is-type.ts:30</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -743,7 +743,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L78">shared/src/is-type.ts:78</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L78">shared/src/is-type.ts:78</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -778,7 +778,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L46">shared/src/is-type.ts:46</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L46">shared/src/is-type.ts:46</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -813,7 +813,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L17">shared/src/is-type.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L17">shared/src/is-type.ts:17</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -836,7 +836,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L113">shared/src/is-type.ts:113</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L113">shared/src/is-type.ts:113</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -872,7 +872,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L25">shared/src/is-type.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L25">shared/src/is-type.ts:25</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -895,7 +895,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L13">shared/src/is-type.ts:13</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L13">shared/src/is-type.ts:13</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -918,7 +918,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L9">shared/src/is-type.ts:9</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L9">shared/src/is-type.ts:9</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-type-parameters-title">Type parameters</h4>
@@ -950,7 +950,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/is-type.ts#L62">shared/src/is-type.ts:62</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/is-type.ts#L62">shared/src/is-type.ts:62</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -985,7 +985,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/map.ts#L43">shared/src/map.ts:43</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/map.ts#L43">shared/src/map.ts:43</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -1053,7 +1053,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/noop.ts#L5">shared/src/noop.ts:5</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/noop.ts#L5">shared/src/noop.ts:5</a></li>
 								</ul>
 							</aside>
 							<h4 class="tsd-parameters-title">Parameters</h4>
@@ -1076,7 +1076,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/shared/src/not.ts#L20">shared/src/not.ts:20</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/shared/src/not.ts#L20">shared/src/not.ts:20</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/docs/modules/_tomato_js_string.html
+++ b/docs/modules/_tomato_js_string.html
@@ -96,7 +96,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/camel-case.ts#L22">string/src/camel-case.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/camel-case.ts#L22">string/src/camel-case.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -132,7 +132,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/is-json.ts#L18">string/src/is-json.ts:18</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/is-json.ts#L18">string/src/is-json.ts:18</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -168,7 +168,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/kebab-case.ts#L22">string/src/kebab-case.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/kebab-case.ts#L22">string/src/kebab-case.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -204,7 +204,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/chinese.ts#L22">string/src/chinese.ts:22</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/chinese.ts#L22">string/src/chinese.ts:22</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -239,7 +239,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/random.ts#L19">string/src/random.ts:19</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/random.ts#L19">string/src/random.ts:19</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -275,7 +275,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/reverse.ts#L17">string/src/reverse.ts:17</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/reverse.ts#L17">string/src/reverse.ts:17</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -310,7 +310,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/substr.ts#L25">string/src/substr.ts:25</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/substr.ts#L25">string/src/substr.ts:25</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">
@@ -358,7 +358,7 @@
 						<li class="tsd-description">
 							<aside class="tsd-sources">
 								<ul>
-									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/5e1a6d2/packages/string/src/substr.ts#L53">string/src/substr.ts:53</a></li>
+									<li>Defined in <a href="https://github.com/tomato-js/tomato/blob/df6f850/packages/string/src/substr.ts#L53">string/src/substr.ts:53</a></li>
 								</ul>
 							</aside>
 							<div class="tsd-comment tsd-typography">

--- a/packages/async/__tests__/p-queue.test.ts
+++ b/packages/async/__tests__/p-queue.test.ts
@@ -1,0 +1,200 @@
+import { Events } from "@tomato-js/events";
+import * as async from "../src";
+const fixture = Symbol("fixture");
+
+describe("async util", () => {
+  describe("PQueue", () => {
+    test("add return promise", async () => {
+      const queue = new async.PQueue();
+      const promise = queue.add(async () => fixture);
+      expect(queue.size()).toBe(0);
+      expect(queue.pending).toBe(1);
+      expect(await promise).toBe(fixture);
+    });
+    test("add multiple times", async () => {
+      const queue = new async.PQueue();
+      const promise = queue.add(async () => fixture);
+      const promise2 = queue.add(async () => {
+        await async.sleep(1000);
+        return fixture;
+      });
+      const promise3 = queue.add(async () => fixture);
+      expect(queue.pending).toBe(3);
+      expect(await promise).toBe(fixture);
+      expect(await promise2).toBe(fixture);
+      expect(await promise3).toBe(fixture);
+    });
+    test("add multiple times", async () => {
+      const queue = new async.PQueue();
+      const promise = queue.add(async () => fixture);
+      const promise2 = queue.add(async () => {
+        await async.sleep(1000);
+        return fixture;
+      });
+      const promise3 = queue.add(async () => fixture);
+      expect(queue.pending).toBe(3);
+      expect(await promise).toBe(fixture);
+      expect(await promise2).toBe(fixture);
+      expect(await promise3).toBe(fixture);
+    });
+    test("add multiple times with active", async () => {
+      const queue = new async.PQueue();
+      let i = 0;
+      queue.on("active", () => {
+        i++;
+      });
+      const promise = queue.add(async () => fixture);
+      const promise2 = queue.add(async () => {
+        await async.sleep(1000);
+        return fixture;
+      });
+      const promise3 = queue.add(async () => fixture);
+      expect(queue.pending).toBe(3);
+      queue.on("idle", () => {
+        expect(i).toBe(3);
+      });
+    });
+    test("add multiple times in order", async () => {
+      const queue = new async.PQueue();
+      let str = "";
+      queue.add(() => (str = str + 1));
+      queue.add(() => (str = str + 2));
+      queue.add(() => (str = str + 3));
+      expect(queue.pending).toBe(3);
+      expect(str).toBe("123");
+    });
+    test("add multiple times in order with async fns", async () => {
+      const queue = new async.PQueue();
+      let str = "";
+      queue.add(async () => {
+        await async.sleep(20);
+        str = str + 1;
+      });
+      queue.add(async () => {
+        await async.sleep(30);
+        str = str + 2;
+      });
+      queue.add(async () => {
+        await async.sleep(10);
+        str = str + 3;
+      });
+      expect(queue.pending).toBe(3);
+      expect(queue.size()).toBe(0);
+      queue.on("idle", () => {
+        expect(queue.pending).toBe(0);
+        expect(queue.size()).toBe(0);
+        expect(str).toBe("312");
+      });
+    });
+    test("add multiple times in order with async fns and concurrency 1", async () => {
+      const queue = new async.PQueue({ concurrency: 1 });
+      let str = "";
+      queue.add(async () => {
+        await async.sleep(20);
+        str = str + 1;
+      });
+      queue.add(async () => {
+        await async.sleep(30000);
+        str = str + 2;
+      });
+      queue.add(async () => {
+        await async.sleep(10);
+        str = str + 3;
+      });
+      expect(queue.pending).toBe(1);
+      expect(queue.size()).toBe(2);
+      queue.on("idle", () => {
+        expect(queue.pending).toBe(0);
+        expect(queue.size()).toBe(0);
+        expect(str).toBe("123");
+      });
+    });
+    test("add multiple times in order with async fns and concurrency 1 and onIdle", async () => {
+      const queue = new async.PQueue({ concurrency: 1 });
+      let str = "";
+      queue.add(async () => {
+        await async.sleep(20);
+        str = str + 1;
+      });
+      queue.add(async () => {
+        await async.sleep(30);
+        str = str + 2;
+      });
+      queue.add(async () => {
+        await async.sleep(10);
+        str = str + 3;
+      });
+      expect(queue.pending).toBe(1);
+      expect(queue.size()).toBe(2);
+      await queue.onIdle();
+      expect(queue.pending).toBe(0);
+      expect(queue.size()).toBe(0);
+      expect(str).toBe("123");
+    });
+    test("addAll()", async () => {
+      const queue = new async.PQueue();
+      const fn = async (): Promise<symbol> => fixture;
+
+      const promise = queue.addAll([fn, fn, fn]);
+      expect(queue.pending).toBe(3);
+      expect(await promise).toEqual([fixture, fixture, fixture]);
+    });
+    test("addAll() with async and sync", async () => {
+      const queue = new async.PQueue();
+      const functions: Array<() => string | Promise<void> | Promise<unknown>> = [
+        () => "sync 1",
+        async () => async.sleep(2000),
+        () => "sync 2",
+        async () => fixture
+      ];
+
+      const promise = queue.addAll(functions);
+      expect(queue.pending).toBe(4);
+      expect(await promise).toEqual(["sync 1", undefined, "sync 2", fixture]);
+    });
+    test("autoStart false", async () => {
+      const queue = new async.PQueue({ autoStart: false });
+
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      expect(queue.pending).toBe(0);
+      expect(queue.size()).toBe(4);
+      expect(queue.isPaused).toBe(true);
+
+      queue.start();
+      expect(queue.pending).toBe(4);
+      expect(queue.size()).toBe(0);
+      expect(queue.isPaused).toBe(false);
+
+      queue.clear();
+      expect(queue.pending).toBe(0);
+    });
+    test("pause()", async () => {
+      const queue = new async.PQueue({ autoStart: false });
+
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      queue.add(async () => await async.sleep(20000));
+      expect(queue.pending).toBe(0);
+      expect(queue.size()).toBe(4);
+      expect(queue.isPaused).toBe(true);
+
+      queue.start();
+      expect(queue.pending).toBe(4);
+      expect(queue.size()).toBe(0);
+      expect(queue.isPaused).toBe(false);
+
+      queue.pause();
+      expect(queue.pending).toBe(4);
+      expect(queue.size()).toBe(0);
+      expect(queue.isPaused).toBe(true);
+    });
+    test("PQueue should be a Events", () => {
+      const queue = new async.PQueue();
+      expect(queue instanceof Events).toBe(true);
+    });
+  });
+});

--- a/packages/async/package.json
+++ b/packages/async/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "npm run clean && run-p build:*",
     "build:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir dist/esm",
-    "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir dist/lib",
+    "build:cjs": "tsc -p tsconfig.json --target ES2019 --module commonjs --outDir dist/lib",
     "clean": "rm -rf dist"
   },
   "bugs": {
@@ -37,6 +37,7 @@
     "npm-run-all": "^4.1.5"
   },
   "dependencies": {
+    "@tomato-js/events": "^0.0.17",
     "@tomato-js/shared": "^0.0.17"
   }
 }

--- a/packages/async/src/index.ts
+++ b/packages/async/src/index.ts
@@ -4,3 +4,5 @@ export { pLog } from "./p-log";
 export { pTap } from "./p-tap";
 export { promisify } from "./promisify";
 export { sleep } from "./sleep";
+
+export { PQueue } from "./p-queue";

--- a/packages/async/src/p-queue.ts
+++ b/packages/async/src/p-queue.ts
@@ -27,7 +27,7 @@ type Queue = QueueItem[];
  * ```
  *   import { PQueue, sleep } from '@tomato-js/async'
  *   const queue = new PQueue({
- *     autoStart:false, // 是否自动开始执行队列
+ *     autoStart:true, // 是否自动开始执行队列
  *     concurrency: 1 //队列执行并发数
  *   });
  *   let str = "";

--- a/packages/async/src/p-queue.ts
+++ b/packages/async/src/p-queue.ts
@@ -1,0 +1,155 @@
+/**
+ * @packageDocumentation
+ * @module @tomato-js/async
+ */
+import { Events } from "@tomato-js/events";
+
+type Options = {
+  autoStart?: boolean;
+  concurrency?: number;
+};
+
+type Task<TaskResultType> = (() => PromiseLike<TaskResultType>) | (() => TaskResultType);
+
+type RunFunction = () => Promise<unknown>;
+
+type QueueItem = {
+  run: RunFunction;
+};
+
+type Queue = QueueItem[];
+/**
+ * 函数描述
+ *
+ * 新增于v0.0.18
+ *
+ * 脚本举例
+ * ```
+ *   import { PQueue, sleep } from '@tomato-js/async'
+ *   const queue = new PQueue({
+ *     autoStart:false, // 是否自动开始执行队列
+ *     concurrency: 1 //队列执行并发数
+ *   });
+ *   let str = "";
+ *   queue.add(async () => {
+ *     await sleep(20);
+ *     str = str + 1;
+ *   });
+ *   queue.add(async () => {
+ *     await sleep(30);
+ *     str = str + 2;
+ *   });
+ *   queue.add(async () => {
+ *     await sleep(10);
+ *     str = str + 3;
+ *   });
+ *   // 同步方法监听
+ *   await queue.onIdle(()=>str)//123;
+ *   // 通过事件监听
+ *   queue.on('idle',()=>str)//123
+ * ```
+ */
+export class PQueue extends Events {
+  isPaused: boolean;
+  private pendingCount = 0;
+  private queue: Queue;
+  private concurrency: number;
+  constructor(options?: Options) {
+    super();
+    options = {
+      autoStart: true,
+      concurrency: Infinity,
+      ...options
+    } as Options;
+    this.isPaused = options.autoStart === false;
+    this.concurrency = options.concurrency!;
+    this.queue = [];
+  }
+  private get doesConcurrentAllowAnother(): boolean {
+    return this.pendingCount < this.concurrency;
+  }
+  private tryToStartAnother() {
+    if (this.queue.length === 0) {
+      if (this.pendingCount === 0) {
+        this.emit("idle");
+      }
+      return false;
+    }
+    // 未暂停则继续执行
+    if (!this.isPaused) {
+      if (this.doesConcurrentAllowAnother) {
+        this.emit("active");
+        this.dequeue()!();
+        return true;
+      }
+    }
+    return false;
+  }
+  private next(): void {
+    this.pendingCount--;
+    this.tryToStartAnother();
+  }
+  private enqueue({ run }: QueueItem) {
+    this.queue.push({ run });
+  }
+  private dequeue() {
+    const item = this.queue.shift();
+    return item?.run;
+  }
+  // while的调用tryToStartAnother，知道其返回false
+  private processQueue() {
+    while (this.tryToStartAnother()) {}
+  }
+  start() {
+    if (!this.isPaused) {
+      return this;
+    }
+    // 将暂停置为false
+    this.isPaused = false;
+
+    this.processQueue();
+    return this;
+  }
+  //设置暂停
+  pause() {
+    this.isPaused = true;
+  }
+  async add<TaskResultsType>(fn: Task<TaskResultsType>) {
+    return new Promise<TaskResultsType>((resolve, reject) => {
+      const run = async (): Promise<void> => {
+        // 未决的promise数量+1
+        this.pendingCount++;
+        try {
+          // 执行传入的promise
+          resolve(await Promise.resolve(fn()));
+        } catch (error) {
+          reject(error);
+        }
+        //调用next
+        this.next();
+      };
+      //将封装好的函数加入queue
+      this.enqueue({ run });
+      this.tryToStartAnother();
+    });
+  }
+  async addAll<TaskResultsType>(fns: ReadonlyArray<Task<TaskResultsType>>) {
+    return Promise.all(fns.map(async fn => this.add(fn)));
+  }
+  async onIdle() {
+    return new Promise((resolve, reject) => {
+      this.on("idle", () => resolve());
+    });
+  }
+  clear() {
+    this.queue = [];
+    this.pendingCount = 0;
+    return true;
+  }
+  size() {
+    return this.queue.length;
+  }
+  get pending() {
+    return this.pendingCount;
+  }
+}

--- a/packages/entry/src/index.ts
+++ b/packages/entry/src/index.ts
@@ -1,5 +1,4 @@
 import * as array from "@tomato-js/array";
-import * as async from "@tomato-js/async";
 import * as cookie from "@tomato-js/cookie";
 import * as element from "@tomato-js/element";
 import * as env from "@tomato-js/env";
@@ -9,4 +8,4 @@ import * as object from "@tomato-js/object";
 import * as path from "@tomato-js/path";
 import * as shared from "@tomato-js/shared";
 import * as string from "@tomato-js/string";
-export { array, async, cookie, element, object, env, func, math, path, shared, string };
+export { array, cookie, element, object, env, func, math, path, shared, string };

--- a/packages/events/__tests__/Events.test.ts
+++ b/packages/events/__tests__/Events.test.ts
@@ -9,7 +9,7 @@ describe("events util", () => {
     });
     test("emit without context", () => {
       const e = new events.Events();
-      e.on("foo", bar => {
+      e.on("foo", (bar: any) => {
         expect(bar).toBe("bar");
       });
       e.emit("foo", "bar");
@@ -19,7 +19,7 @@ describe("events util", () => {
       const e = new events.Events();
       e.on(
         "foo",
-        function(bar) {
+        function(bar: any) {
           expect(bar).toBe("bar");
           //@ts-ignore
           expect(this).toEqual(context);

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -27,7 +27,7 @@
   "scripts": {
     "build": "npm run clean && run-p build:*",
     "build:esm": "tsc -p tsconfig.json --target ESNext --module ESNext --outDir dist/esm",
-    "build:cjs": "tsc -p tsconfig.json --target ESNext --module commonjs --outDir dist/lib",
+    "build:cjs": "tsc -p tsconfig.json --target ES2018 --module commonjs --outDir dist/lib",
     "clean": "rm -rf dist"
   },
   "bugs": {


### PR DESCRIPTION
Add PQueue class as promise queue

```
    import { PQueue, sleep } from '@tomato-js/async'
    const queue = new PQueue({
      autoStart:true, // 是否自动开始执行队列
      concurrency: 1 //队列执行并发数
    });
    let str = "";
    queue.add(async () => {
      await sleep(20);
      str = str + 1;
    });
    queue.add(async () => {
      await sleep(30);
      str = str + 2;
    });
    queue.add(async () => {
      await sleep(10);
      str = str + 3;
    });
    // 同步方法监听
    await queue.onIdle(()=>str)//123;
   // 通过事件监听
    queue.on('idle',()=>str)//123
```
